### PR TITLE
Add host fixture test and fix Keccak rotation constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build fixture test
+        run: g++ -std=c++17 -Isrc tests/fixture_test.cpp -o fixture_test
+      - name: Run fixture test
+        run: ./fixture_test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # solady-vanity
+
+CUDA-based vanity searcher for Solady CREATE3 deployments. The program scans
+CREATE3 salts so the resulting contract address matches a user-supplied hex
+prefix. Usage:
+
+```
+nvcc -O3 -Xcompiler -fno-exceptions -arch=sm_89 -o create3_cuda src/main.cu
+
+./create3_cuda \
+  --deployer 0xBA203fFDB6727c59e31D73d66290fFb47728e4Cb \
+  --init-hash 0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f \
+  --prefix d0000000
+```
+
+On success, the tool prints the 32-byte salt and the checksum-encoded CREATE3
+address.

--- a/src/hex.cuh
+++ b/src/hex.cuh
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstddef>
+#include <string>
+
+inline std::string strip_0x(const std::string &input) {
+    if (input.size() >= 2 && input[0] == '0' && (input[1] == 'x' || input[1] == 'X')) {
+        return input.substr(2);
+    }
+    return input;
+}
+
+inline int hex_char_to_value(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+inline bool parse_hex_exact(const std::string &hex, uint8_t *out, std::size_t bytes) {
+    const std::string clean = strip_0x(hex);
+    if (clean.size() != bytes * 2) {
+        return false;
+    }
+    for (std::size_t i = 0; i < bytes; ++i) {
+        const int hi = hex_char_to_value(clean[2 * i]);
+        const int lo = hex_char_to_value(clean[2 * i + 1]);
+        if (hi < 0 || lo < 0) return false;
+        out[i] = static_cast<uint8_t>((hi << 4) | lo);
+    }
+    return true;
+}
+
+inline std::string bytes_to_hex(const uint8_t *data, std::size_t len, bool uppercase = false) {
+    std::string out;
+    out.resize(len * 2);
+    const char *digits = uppercase ? "0123456789ABCDEF" : "0123456789abcdef";
+    for (std::size_t i = 0; i < len; ++i) {
+        const uint8_t byte = data[i];
+        out[2 * i] = digits[byte >> 4];
+        out[2 * i + 1] = digits[byte & 0x0F];
+    }
+    return out;
+}
+
+inline bool parse_prefix(const std::string &hex, std::array<uint8_t, 20> &target,
+                         int &cmp_bytes, int &has_odd, uint8_t &last_mask) {
+    const std::string clean = strip_0x(hex);
+    if (clean.empty() || clean.size() > 40) {
+        return false;
+    }
+    for (auto &b : target) b = 0;
+    const std::size_t nibbles = clean.size();
+    cmp_bytes = static_cast<int>((nibbles + 1) / 2);
+    has_odd = static_cast<int>(nibbles & 1U);
+    last_mask = has_odd ? 0xF0 : 0x00;
+    std::size_t i = 0;
+    while (i + 1 < nibbles) {
+        const int hi = hex_char_to_value(clean[i]);
+        const int lo = hex_char_to_value(clean[i + 1]);
+        if (hi < 0 || lo < 0) return false;
+        target[i / 2] = static_cast<uint8_t>((hi << 4) | lo);
+        i += 2;
+    }
+    if (has_odd) {
+        const int hi = hex_char_to_value(clean.back());
+        if (hi < 0) return false;
+        target[cmp_bytes - 1] = static_cast<uint8_t>(hi << 4);
+    }
+    return true;
+}
+
+inline bool starts_with_prefix(const uint8_t address[20], const std::array<uint8_t, 20> &target,
+                               int cmp_bytes, int has_odd, uint8_t last_mask) {
+    const int full_bytes = cmp_bytes - (has_odd ? 1 : 0);
+    for (int i = 0; i < full_bytes; ++i) {
+        if (address[i] != target[i]) {
+            return false;
+        }
+    }
+    if (has_odd) {
+        const int idx = cmp_bytes - 1;
+        if ((address[idx] & last_mask) != (target[idx] & last_mask)) {
+            return false;
+        }
+    }
+    return true;
+}
+

--- a/src/keccak.cuh
+++ b/src/keccak.cuh
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+#if defined(__CUDA_ARCH__)
+#define HD __host__ __device__ __forceinline__
+#else
+#define HD inline
+#endif
+
+HD uint64_t rotl64(uint64_t x, int n) {
+    return (x << n) | (x >> (64 - n));
+}
+
+HD void keccak_f1600(uint64_t state[25]) {
+    static constexpr uint64_t RC[24] = {
+        0x0000000000000001ULL, 0x0000000000008082ULL,
+        0x800000000000808aULL, 0x8000000080008000ULL,
+        0x000000000000808bULL, 0x0000000080000001ULL,
+        0x8000000080008081ULL, 0x8000000000008009ULL,
+        0x000000000000008aULL, 0x0000000000000088ULL,
+        0x0000000080008009ULL, 0x000000008000000aULL,
+        0x000000008000808bULL, 0x800000000000008bULL,
+        0x8000000000008089ULL, 0x8000000000008003ULL,
+        0x8000000000008002ULL, 0x8000000000000080ULL,
+        0x000000000000800aULL, 0x800000008000000aULL,
+        0x8000000080008081ULL, 0x8000000000008080ULL,
+        0x0000000080000001ULL, 0x8000000080008008ULL
+    };
+
+    static constexpr int ROTC[24] = {
+         1,  3,  6, 10, 15, 21, 28, 36,
+        45, 55,  2, 14, 27, 41, 56,  8,
+        25, 43, 62, 18, 39, 61, 20, 44
+    };
+
+    static constexpr int PILN[24] = {
+        10,  7, 11, 17, 18,  3,  5, 16,
+         8, 21, 24,  4, 15, 23, 19, 13,
+        12,  2, 20, 14, 22,  9,  6,  1
+    };
+
+    uint64_t bc[5];
+
+#if defined(__CUDA_ARCH__)
+#pragma unroll 24
+#endif
+    for (int round = 0; round < 24; ++round) {
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int i = 0; i < 5; ++i) {
+            bc[i] = state[i] ^ state[i + 5] ^ state[i + 10] ^ state[i + 15] ^ state[i + 20];
+        }
+
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int i = 0; i < 5; ++i) {
+            const uint64_t t = bc[(i + 4) % 5] ^ rotl64(bc[(i + 1) % 5], 1);
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+            for (int j = 0; j < 25; j += 5) {
+                state[j + i] ^= t;
+            }
+        }
+
+        uint64_t t = state[1];
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int i = 0; i < 24; ++i) {
+            const int idx = PILN[i];
+            const uint64_t current = state[idx];
+            state[idx] = rotl64(t, ROTC[i]);
+            t = current;
+        }
+
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int j = 0; j < 25; j += 5) {
+            const uint64_t a0 = state[j];
+            const uint64_t a1 = state[j + 1];
+            const uint64_t a2 = state[j + 2];
+            const uint64_t a3 = state[j + 3];
+            const uint64_t a4 = state[j + 4];
+            state[j]     = a0 ^ ((~a1) & a2);
+            state[j + 1] = a1 ^ ((~a2) & a3);
+            state[j + 2] = a2 ^ ((~a3) & a4);
+            state[j + 3] = a3 ^ ((~a4) & a0);
+            state[j + 4] = a4 ^ ((~a0) & a1);
+        }
+
+        state[0] ^= RC[round];
+    }
+}
+
+HD void keccak256(const uint8_t *data, std::size_t len, uint8_t out[32]) {
+    uint64_t state[25];
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+    for (int i = 0; i < 25; ++i) state[i] = 0;
+
+    constexpr std::size_t rate = 136;
+
+    std::size_t offset = 0;
+    while (len >= rate) {
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (std::size_t i = 0; i < rate / 8; ++i) {
+            uint64_t lane = 0;
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+            for (int b = 0; b < 8; ++b) {
+                lane |= static_cast<uint64_t>(data[offset + 8 * i + b]) << (8 * b);
+            }
+            state[i] ^= lane;
+        }
+        keccak_f1600(state);
+        offset += rate;
+        len -= rate;
+    }
+
+    uint8_t block[rate];
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+    for (std::size_t i = 0; i < rate; ++i) block[i] = 0;
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+    for (std::size_t i = 0; i < len; ++i) {
+        block[i] = data[offset + i];
+    }
+    block[len] ^= 0x01;
+    block[rate - 1] ^= 0x80;
+
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+    for (std::size_t i = 0; i < rate / 8; ++i) {
+        uint64_t lane = 0;
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int b = 0; b < 8; ++b) {
+            lane |= static_cast<uint64_t>(block[8 * i + b]) << (8 * b);
+        }
+        state[i] ^= lane;
+    }
+    keccak_f1600(state);
+
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+    for (int i = 0; i < 4; ++i) {
+        uint64_t lane = state[i];
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+        for (int b = 0; b < 8; ++b) {
+            out[i * 8 + b] = static_cast<uint8_t>((lane >> (8 * b)) & 0xFF);
+        }
+    }
+}
+
+#undef HD
+

--- a/src/main.cu
+++ b/src/main.cu
@@ -1,0 +1,237 @@
+#include <cuda_runtime.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "hex.cuh"
+#include "keccak.cuh"
+#include "rlp.cuh"
+
+__constant__ uint8_t c_deployer[20];
+__constant__ uint8_t c_init_hash[32];
+__constant__ uint8_t c_target_prefix[20];
+__constant__ int c_cmp_bytes;
+__constant__ int c_has_odd;
+__constant__ uint8_t c_last_mask;
+
+#define CUDA_CHECK(expr)                                                     \
+    do {                                                                     \
+        cudaError_t _err = (expr);                                           \
+        if (_err != cudaSuccess) {                                           \
+            std::cerr << "CUDA error: " << cudaGetErrorString(_err)          \
+                      << " (" << __FILE__ << ":" << __LINE__ << ")"        \
+                      << std::endl;                                          \
+            std::exit(EXIT_FAILURE);                                         \
+        }                                                                    \
+    } while (0)
+
+__global__ void grind(uint64_t salt_base, uint64_t *hit_salt, int *found_flag) {
+    if (atomicAdd(found_flag, 0)) return;
+
+    const uint64_t idx = salt_base + blockIdx.x * blockDim.x + threadIdx.x;
+
+    uint8_t salt[32];
+#pragma unroll
+    for (int b = 0; b < 32; ++b) {
+        salt[31 - b] = static_cast<uint8_t>((idx >> (b * 8)) & 0xFF);
+    }
+
+    uint8_t pre[85];
+    pre[0] = 0xFF;
+#pragma unroll
+    for (int i = 0; i < 20; ++i) pre[1 + i] = c_deployer[i];
+#pragma unroll
+    for (int i = 0; i < 32; ++i) pre[21 + i] = salt[i];
+#pragma unroll
+    for (int i = 0; i < 32; ++i) pre[53 + i] = c_init_hash[i];
+
+    uint8_t h1[32];
+    keccak256(pre, sizeof(pre), h1);
+
+    uint8_t proxy[20];
+#pragma unroll
+    for (int i = 0; i < 20; ++i) proxy[i] = h1[12 + i];
+
+    uint8_t rlp_bytes[23];
+    rlp_addr_nonce(rlp_bytes, proxy);
+
+    uint8_t h2[32];
+    keccak256(rlp_bytes, sizeof(rlp_bytes), h2);
+
+    const uint8_t *address = h2 + 12;
+
+    const int cmp_bytes = c_cmp_bytes;
+    const int has_odd = c_has_odd;
+    const uint8_t mask = c_last_mask;
+
+#pragma unroll
+    for (int i = 0; i < 20; ++i) {
+        if (i < cmp_bytes - (has_odd ? 1 : 0)) {
+            if (address[i] != c_target_prefix[i]) return;
+        } else if (has_odd && i == cmp_bytes - 1) {
+            if ((address[i] & mask) != (c_target_prefix[i] & mask)) return;
+            break;
+        } else {
+            break;
+        }
+    }
+
+    if (atomicCAS(found_flag, 0, 1) == 0) {
+        *hit_salt = idx;
+    }
+}
+
+std::string keccak_hex(const std::string &input) {
+    std::vector<uint8_t> bytes(input.begin(), input.end());
+    uint8_t digest[32];
+    keccak256(bytes.data(), bytes.size(), digest);
+    return bytes_to_hex(digest, 32, false);
+}
+
+std::string checksum_address(const uint8_t address[20]) {
+    const std::string lower = bytes_to_hex(address, 20, false);
+    const std::string hash = keccak_hex(lower);
+    std::string out = "0x";
+    out.reserve(42);
+    for (std::size_t i = 0; i < lower.size(); ++i) {
+        char c = lower[i];
+        if (c >= 'a' && c <= 'f') {
+            const int nibble = hex_char_to_value(hash[i]);
+            if (nibble > 7) {
+                c = static_cast<char>(c - 'a' + 'A');
+            }
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+void usage(const char *prog) {
+    std::cerr << "Usage: " << prog << " --deployer <addr> --init-hash <hash> --prefix <hex>" << std::endl;
+}
+
+int main(int argc, char **argv) {
+    std::string deployer_hex;
+    std::string init_hex;
+    std::string prefix_hex;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--deployer" && i + 1 < argc) {
+            deployer_hex = argv[++i];
+        } else if (arg == "--init-hash" && i + 1 < argc) {
+            init_hex = argv[++i];
+        } else if (arg == "--prefix" && i + 1 < argc) {
+            prefix_hex = argv[++i];
+        } else {
+            usage(argv[0]);
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (deployer_hex.empty() || init_hex.empty() || prefix_hex.empty()) {
+        usage(argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    std::array<uint8_t, 20> deployer{};
+    std::array<uint8_t, 32> init_hash{};
+    std::array<uint8_t, 20> target{};
+
+    if (!parse_hex_exact(deployer_hex, deployer.data(), deployer.size())) {
+        std::cerr << "Invalid deployer address" << std::endl;
+        return EXIT_FAILURE;
+    }
+    if (!parse_hex_exact(init_hex, init_hash.data(), init_hash.size())) {
+        std::cerr << "Invalid init hash" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    int cmp_bytes = 0;
+    int has_odd = 0;
+    uint8_t last_mask = 0;
+    if (!parse_prefix(prefix_hex, target, cmp_bytes, has_odd, last_mask)) {
+        std::cerr << "Invalid prefix" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    CUDA_CHECK(cudaMemcpyToSymbol(c_deployer, deployer.data(), deployer.size()));
+    CUDA_CHECK(cudaMemcpyToSymbol(c_init_hash, init_hash.data(), init_hash.size()));
+    CUDA_CHECK(cudaMemcpyToSymbol(c_target_prefix, target.data(), target.size()));
+    CUDA_CHECK(cudaMemcpyToSymbol(c_cmp_bytes, &cmp_bytes, sizeof(int)));
+    CUDA_CHECK(cudaMemcpyToSymbol(c_has_odd, &has_odd, sizeof(int)));
+    CUDA_CHECK(cudaMemcpyToSymbol(c_last_mask, &last_mask, sizeof(uint8_t)));
+
+    uint64_t *d_hit_salt = nullptr;
+    int *d_found_flag = nullptr;
+    CUDA_CHECK(cudaMalloc(&d_hit_salt, sizeof(uint64_t)));
+    CUDA_CHECK(cudaMalloc(&d_found_flag, sizeof(int)));
+    CUDA_CHECK(cudaMemset(d_found_flag, 0, sizeof(int)));
+
+    const dim3 block_dim(256);
+    const dim3 grid_dim(4096);
+    const uint64_t stride = static_cast<uint64_t>(block_dim.x) * grid_dim.x;
+
+    uint64_t salt_base = 0;
+    uint64_t host_hit_salt = 0;
+
+    while (true) {
+        grind<<<grid_dim, block_dim>>>(salt_base, d_hit_salt, d_found_flag);
+        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cudaDeviceSynchronize());
+
+        int found = 0;
+        CUDA_CHECK(cudaMemcpy(&found, d_found_flag, sizeof(int), cudaMemcpyDeviceToHost));
+        if (found) {
+            CUDA_CHECK(cudaMemcpy(&host_hit_salt, d_hit_salt, sizeof(uint64_t), cudaMemcpyDeviceToHost));
+            break;
+        }
+        salt_base += stride;
+    }
+
+    CUDA_CHECK(cudaFree(d_hit_salt));
+    CUDA_CHECK(cudaFree(d_found_flag));
+
+    std::array<uint8_t, 32> salt_bytes{};
+    for (int b = 0; b < 32; ++b) {
+        salt_bytes[31 - b] = static_cast<uint8_t>((host_hit_salt >> (8 * b)) & 0xFF);
+    }
+
+    uint8_t pre[85];
+    pre[0] = 0xFF;
+    std::memcpy(pre + 1, deployer.data(), deployer.size());
+    std::memcpy(pre + 21, salt_bytes.data(), salt_bytes.size());
+    std::memcpy(pre + 53, init_hash.data(), init_hash.size());
+
+    uint8_t h1[32];
+    keccak256(pre, sizeof(pre), h1);
+
+    uint8_t proxy[20];
+    for (int i = 0; i < 20; ++i) proxy[i] = h1[12 + i];
+
+    uint8_t rlp_bytes[23];
+    rlp_addr_nonce(rlp_bytes, proxy);
+
+    uint8_t h2[32];
+    keccak256(rlp_bytes, sizeof(rlp_bytes), h2);
+    const uint8_t *final_address = h2 + 12;
+
+    if (!starts_with_prefix(final_address, target, cmp_bytes, has_odd, last_mask)) {
+        std::cerr << "Internal error: found salt does not satisfy prefix" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    const std::string salt_hex = bytes_to_hex(salt_bytes.data(), salt_bytes.size(), true);
+    const std::string address_checksum = checksum_address(final_address);
+
+    std::cout << "salt: 0x" << salt_hex << std::endl;
+    std::cout << "address: " << address_checksum << std::endl;
+
+    return EXIT_SUCCESS;
+}
+

--- a/src/rlp.cuh
+++ b/src/rlp.cuh
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+#if defined(__CUDA_ARCH__)
+#define HD_INLINE __device__ __forceinline__
+#else
+#define HD_INLINE inline
+#endif
+
+HD_INLINE void rlp_addr_nonce(uint8_t out[23], const uint8_t address[20]) {
+    out[0] = 0xD6;
+    out[1] = 0x94;
+#if defined(__CUDA_ARCH__)
+#pragma unroll
+#endif
+    for (int i = 0; i < 20; ++i) {
+        out[2 + i] = address[i];
+    }
+    out[22] = 0x01;
+}
+
+#undef HD_INLINE
+

--- a/tests/fixture_test.cpp
+++ b/tests/fixture_test.cpp
@@ -1,0 +1,91 @@
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "hex.cuh"
+#include "keccak.cuh"
+#include "rlp.cuh"
+
+std::string keccak_hex(const uint8_t *data, std::size_t len) {
+    std::array<uint8_t, 32> digest{};
+    keccak256(data, len, digest.data());
+    return bytes_to_hex(digest.data(), digest.size(), false);
+}
+
+std::string keccak_hex(const std::string &input) {
+    return keccak_hex(reinterpret_cast<const uint8_t *>(input.data()), input.size());
+}
+
+std::string checksum_address(const uint8_t address[20]) {
+    const std::string lower = bytes_to_hex(address, 20, false);
+    const std::string hash = keccak_hex(lower);
+    std::string out = "0x";
+    out.reserve(42);
+    for (std::size_t i = 0; i < lower.size(); ++i) {
+        char c = lower[i];
+        if (c >= 'a' && c <= 'f') {
+            const int nibble = hex_char_to_value(hash[i]);
+            if (nibble > 7) {
+                c = static_cast<char>(c - 'a' + 'A');
+            }
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+int main() {
+    // Basic Keccak-256 test vectors to ensure the permutation is correct on host builds.
+    const std::string expected_empty = "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470";
+    const std::string expected_abc = "4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45";
+    const std::string actual_empty = keccak_hex(nullptr, 0);
+    const std::string actual_abc = keccak_hex("abc");
+    assert(actual_empty == expected_empty);
+    assert(actual_abc == expected_abc);
+
+    const std::string deployer_hex = "0xBA203fFDB6727c59e31D73d66290fFb47728e4Cb";
+    const std::string init_hash_hex = "0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f";
+    const std::string salt_hex = "0x0000000000000000000000000000000000000000000000000000000009b5beb5";
+    const std::string expected_address = "0xd000007fB7b2683688561Ff7Fa6c107D2206A5B8";
+
+    std::array<uint8_t, 20> deployer{};
+    std::array<uint8_t, 32> init_hash{};
+    std::array<uint8_t, 32> salt{};
+
+    assert(parse_hex_exact(deployer_hex, deployer.data(), deployer.size()));
+    assert(parse_hex_exact(init_hash_hex, init_hash.data(), init_hash.size()));
+    assert(parse_hex_exact(salt_hex, salt.data(), salt.size()));
+
+    std::array<uint8_t, 85> pre{};
+    pre[0] = 0xFF;
+    std::memcpy(pre.data() + 1, deployer.data(), deployer.size());
+    std::memcpy(pre.data() + 21, salt.data(), salt.size());
+    std::memcpy(pre.data() + 53, init_hash.data(), init_hash.size());
+
+    std::array<uint8_t, 32> h1{};
+    keccak256(pre.data(), pre.size(), h1.data());
+
+    std::array<uint8_t, 20> proxy{};
+    for (int i = 0; i < 20; ++i) {
+        proxy[i] = h1[12 + i];
+    }
+
+    std::array<uint8_t, 23> rlp_bytes{};
+    rlp_addr_nonce(rlp_bytes.data(), proxy.data());
+
+    std::array<uint8_t, 32> h2{};
+    keccak256(rlp_bytes.data(), rlp_bytes.size(), h2.data());
+
+    std::array<uint8_t, 20> final_address{};
+    for (int i = 0; i < 20; ++i) {
+        final_address[i] = h2[12 + i];
+    }
+
+    const std::string checksum = checksum_address(final_address.data());
+    assert(checksum == expected_address);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- correct the Keccak-f[1600] rotation schedule so the GPU/host hash matches known vectors
- add a CPU fixture test that recomputes the provided CREATE3 salt/address pair and basic Keccak-256 vectors
- run the fixture test in GitHub Actions to give CI coverage without requiring CUDA hardware

## Testing
- `g++ -std=c++17 -Isrc tests/fixture_test.cpp -o fixture_test && ./fixture_test`

------
https://chatgpt.com/codex/tasks/task_e_68d7fce8227c832aa081f025c990f307