### PR TITLE
Add ETA reporting and helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 CUDA-based vanity searcher for Solady CREATE3 deployments. The program scans
 CREATE3 salts so the resulting contract address matches a user-supplied hex
-prefix. Usage:
+prefix. Build and run with the helper script:
 
 ```
-nvcc -O3 -Xcompiler -fno-exceptions -arch=sm_89 -o create3_cuda src/main.cu
-
-./create3_cuda \
+./run.sh \
   --deployer 0xBA203fFDB6727c59e31D73d66290fFb47728e4Cb \
   --init-hash 0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f \
   --prefix d0000000
 ```
 
-On success, the tool prints the 32-byte salt and the checksum-encoded CREATE3
-address.
+The console status now also reports the runtime, current hash rate, and the
+expected time to find a match at the observed rate. On success, the tool prints
+the 32-byte salt, checksum-encoded CREATE3 address, elapsed time, and the
+expected find time at the recorded hash rate.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+cd "$SCRIPT_DIR"
+
+BUILD_DIR="build"
+BINARY_NAME="create3_cuda"
+OUTPUT_PATH="$BUILD_DIR/$BINARY_NAME"
+
+mkdir -p "$BUILD_DIR"
+
+nvcc -O3 -Xcompiler -fno-exceptions -arch=sm_89 -o "$OUTPUT_PATH" src/main.cu
+
+"$OUTPUT_PATH" "$@"


### PR DESCRIPTION
## Summary
- add runtime and ETA reporting to the vanity search status and hit output without increasing kernel work
- compute expected hit duration from the requested prefix length and reuse it for host-side logging
- add a run.sh helper that builds the CUDA binary before execution and document the new workflow in the README

## Testing
- `timeout 5 ./run.sh --deployer 0xBA203fFDB6727c59e31D73d66290fFb47728e4Cb --init-hash 0x21c35dbe1b344a2488cf3321d6ce542f8e9f305544ff09e4993a62319a497c1f --prefix d0000000` *(fails: nvcc: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d91d408e34832ab585864ac1743386