### PR TITLE
Clarify deployer instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ chmod +x run.sh
 
 ### 6. Run the Vanity Search
 
-Replace `--prefix` with your desired hex prefix. Use `0x0000000000000000000000000000000000000000` as the deployer (placeholder). By default the tool uses Solady's CREATE3 init code hash; pass `--init-hash` if you need to override it for a custom contract.
+Replace `--prefix` with your desired hex prefix and set `--deployer` to the address of your CREATE3 factory contract. By default the tool uses Solady's CREATE3 init code hash; pass `--init-hash` if you need to override it for a custom contract.
 
 ```bash
 ./run.sh \
-  --deployer 0x0000000000000000000000000000000000000000 \
+  --deployer 0xYourCreate3FactoryAddressHere \
   --prefix d0000000
 ```
 


### PR DESCRIPTION
## Summary
- clarify that users should supply their CREATE3 factory address as the deployer value
- update the sample command to show a placeholder for the factory address instead of all zeros

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9944e01f4832aa9e7de82fa76230a